### PR TITLE
Add option to include lua files

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ build = {
     -- Optional: if set to `false` pass `--no-default-features` to cargo
     default_features = false,
 
+    -- Optional: copy additional files to lua dir, can specify source path
+    include = {
+        "file.lua",
+        ["path/to/another/file.lua"] = "another-file.lua",
+    },
+
     -- Optional: pass additional features
     features = {"extra", "features"}
 }

--- a/src/luarocks/build/rust-mlua.lua
+++ b/src/luarocks/build/rust-mlua.lua
@@ -84,6 +84,21 @@ function mlua.run(rockspec, no_install)
                 return nil, "Failed installing " .. src .. " in " .. dst .. ": " .. err
             end
         end
+
+        local cwd = dir.dir_name(rockspec.local_abs_filename)
+        local luadir = path.lua_dir(rockspec.name, rockspec.version)
+
+        fs.make_dir(dir.dir_name(luadir))
+        for to, from in pairs(rockspec.build.include) do
+            if type(to) == "number" then
+                to = from
+            end
+            to = dir.path(luadir, to)
+            local ok, err = fs.copy(dir.path(cwd, from), to, "exec")
+            if not ok then
+                return nil, "Failed copying " .. from .. " in " .. to .. ": " .. err
+            end
+        end
     end
 
     return true

--- a/src/luarocks/build/rust-mlua.lua
+++ b/src/luarocks/build/rust-mlua.lua
@@ -85,7 +85,7 @@ function mlua.run(rockspec, no_install)
             end
         end
 
-        local cwd = dir.dir_name(rockspec.local_abs_filename)
+        local cwd = dir.path(dir.dir_name(rockspec.local_abs_filename), rockspec.name)
         local luadir = path.lua_dir(rockspec.name, rockspec.version)
 
         fs.make_dir(dir.dir_name(luadir))

--- a/src/luarocks/build/rust-mlua.lua
+++ b/src/luarocks/build/rust-mlua.lua
@@ -89,9 +89,9 @@ function mlua.run(rockspec, no_install)
         local luadir = path.lua_dir(rockspec.name, rockspec.version)
 
         fs.make_dir(dir.dir_name(luadir))
-        for to, from in pairs(rockspec.build.include) do
-            if type(to) == "number" then
-                to = from
+        for from, to in pairs(rockspec.build.include) do
+            if type(from) == "number" then
+                from = to
             end
             to = dir.path(luadir, to)
             local ok, err = fs.copy(dir.path(cwd, from), to, "exec")


### PR DESCRIPTION
allows to copy lua files into LUADIR while installing, for providing loader wrappers or type annotations. behaves like `modules` key: can be an array (file will be copied without renaming) or a `from => to` table

my example use case: providing type annotations directly inside the rock itself: apart from the `(lib|)codemp.(so|dll)` native which gets built, I want to include:
 * `annotations.lua`
 * `codemp.lua` (and use it as loader, while renaming the native ext to `codemp_native`)

so my `rockspec.build` will look like this:
```lua
build = {
	type = "rust-mlua",
	modules = {
		["codemp_native"] = "codemp"
	},
	target_path = "../..",
	include = {
		"codemp.lua",
		"annotations.lua",
	}
}
```

for reference, loader looks like this:
```lua
---@module 'annotations'
---@type Codemp
local native = require('codemp.native')
return native
```