### PR TITLE
Pass some info from LuaRocks manifest like is already done for Cargo manifest

### DIFF
--- a/src/luarocks/build/rust-mlua.lua
+++ b/src/luarocks/build/rust-mlua.lua
@@ -35,6 +35,11 @@ function mlua.run(rockspec, no_install)
         return nil, "Lua version " .. lua_version .. " is not supported"
     end
 
+    local envs = {}
+    for _, key in ipairs({ "package", "version" }) do
+        envs[("LUA_ROCKSPEC_%s"):format(key:upper())] = fs.Q(rockspec[key])
+    end
+
     local cmd = {"cargo build --release"}
 
     local target_path = rockspec.build and rockspec.build.target_path or "target"
@@ -57,7 +62,7 @@ function mlua.run(rockspec, no_install)
     table.insert(cmd, "--features")
     table.insert(cmd, table.concat(features, ","))
 
-    if not fs.execute(table.concat(cmd, " ")) then
+    if not fs.execute_env(envs, table.concat(cmd, " ")) then
         return nil, "Failed building."
     end
 


### PR DESCRIPTION
This makes select fields from the rockspec (namely the ones that are both mandatory and strings, not tables) available as env vars during the build phase. This makes them accessable in Cargo's `build.rs` similar to how many fields from the Cargo.toml manifest are available. For example CARGO_PKG_VERSION shows the version from the Rust manifest. Now you can also get the version from the Lua manifest with LUA_ROCKSPEC_VERSION. This will also include the rockrel segment, information that can't be derived from the Cargo manifest data alone.
