### PR TITLE
feat: support passing extra cargo args

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ build = {
     -- Optional: if set to `false` pass `--no-default-features` to cargo
     default_features = false,
 
+    -- Optional: additional flags to be passed in the cargo invocation
+    cargo_extra_args = {"--package, foo", "--locked"},
+
     -- Optional: copy additional files to lua dir, can specify source path
     include = {
         "file.lua",

--- a/src/luarocks/build/rust-mlua.lua
+++ b/src/luarocks/build/rust-mlua.lua
@@ -40,6 +40,10 @@ function mlua.run(rockspec, no_install)
 
     local cmd = {"cargo build --release"}
 
+    for _, extra_arg in ipairs(rockspec.build.cargo_extra_args or {}) do
+        table.insert(cmd, extra_arg)
+    end
+
     local target_path = rockspec.build and rockspec.build.target_path or "target"
     table.insert(cmd, "--target-dir=" .. fs.Q(target_path))
 


### PR DESCRIPTION
This PR adds support for passing additional flags to the cargo invocation.

My use case is a rust project with multiple crates, only one of which is a rust-mlua luarocks package.